### PR TITLE
Add onboarding info

### DIFF
--- a/src/components/atoms/icons/icons.jsx
+++ b/src/components/atoms/icons/icons.jsx
@@ -510,6 +510,103 @@ const Icons = ({ type, width, height, opacity, fill, onClick, stroke }) => {
                     <div></div>
                 </Styles.Loader>
             )
+        case 'users':
+            return (
+                <Styles.Icon width={width} height={height} opacity={opacity} fill={fill}>
+                    <svg
+                        width="29"
+                        height="29"
+                        viewBox="0 0 29 29"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <g>
+                            <path
+                                d="M20.5416 25.375V22.9583C20.5416 21.6765 20.0324 20.4471 19.1259 19.5407C18.2195 18.6342 16.9901 18.125 15.7083 18.125H6.04158C4.75971 18.125 3.53033 18.6342 2.6239 19.5407C1.71748 20.4471 1.20825 21.6765 1.20825 22.9583V25.375"
+                                stroke="white"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M10.8751 13.2917C13.5445 13.2917 15.7084 11.1277 15.7084 8.45833C15.7084 5.78896 13.5445 3.625 10.8751 3.625C8.20571 3.625 6.04175 5.78896 6.04175 8.45833C6.04175 11.1277 8.20571 13.2917 10.8751 13.2917Z"
+                                stroke="white"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M27.7917 25.375V22.9584C27.7909 21.8874 27.4345 20.8471 26.7784 20.0007C26.1223 19.1543 25.2037 18.5498 24.1667 18.2821"
+                                stroke="white"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M19.3333 3.7821C20.3729 4.0483 21.2944 4.65295 21.9525 5.50073C22.6105 6.34851 22.9677 7.39119 22.9677 8.4644C22.9677 9.5376 22.6105 10.5803 21.9525 11.4281C21.2944 12.2758 20.3729 12.8805 19.3333 13.1467"
+                                stroke="white"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </g>
+                    </svg>
+                </Styles.Icon>
+            )
+        case 'forward':
+            return (
+                <Styles.Icon width={width} height={height} opacity={opacity} fill={fill}>
+                    <svg
+                        width="29"
+                        height="21"
+                        viewBox="0 0 29 21"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M16 20L28 10.5L16 1V20Z"
+                            stroke="white"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                        <path
+                            d="M1 20L13 10.5L1 1V20Z"
+                            stroke="white"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    </svg>
+                </Styles.Icon>
+            )
+        case 'lock':
+            return (
+                <Styles.Icon width={width} height={height} opacity={opacity} fill={fill}>
+                    <svg
+                        width="26"
+                        height="29"
+                        viewBox="0 0 26 29"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M22.3333 13H3.66667C2.19391 13 1 14.221 1 15.7273V25.2727C1 26.779 2.19391 28 3.66667 28H22.3333C23.8061 28 25 26.779 25 25.2727V15.7273C25 14.221 23.8061 13 22.3333 13Z"
+                            stroke="white"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                        <path
+                            d="M6 13V7.66667C6 5.89856 6.7375 4.20286 8.05025 2.95262C9.36301 1.70238 11.1435 1 13 1C14.8565 1 16.637 1.70238 17.9497 2.95262C19.2625 4.20286 20 5.89856 20 7.66667V13"
+                            stroke="white"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    </svg>
+                </Styles.Icon>
+            )
     }
 }
 

--- a/src/components/organisms/loginSteps/loginLanding/loginLanding.jsx
+++ b/src/components/organisms/loginSteps/loginLanding/loginLanding.jsx
@@ -44,7 +44,7 @@ const LoginLanding = () => {
                         <li>
                             <Icons type="lock" width="1.7em" height="1.7em" />
                             <div>
-                                <p>Je informatie is veilig</p>
+                                <p>Het is veilig</p>
                                 <p>We beveiligen je data en doen niets zonder jouw toestemming.</p>
                             </div>
                         </li>

--- a/src/components/organisms/loginSteps/loginLanding/loginLanding.jsx
+++ b/src/components/organisms/loginSteps/loginLanding/loginLanding.jsx
@@ -1,7 +1,7 @@
 // React imports
 import React from 'react'
 import * as Styles from './loginLanding.styles.js'
-import { ButtonPrimary } from 'components/atoms/index.js'
+import { ButtonPrimary, Icons } from 'components/atoms/index.js'
 
 // React component
 const LoginLanding = () => {
@@ -23,7 +23,32 @@ const LoginLanding = () => {
                     <h1>
                         Gemakkelijk <br /> online inchecken
                     </h1>
-                    <p>En een overzicht van jouw reserveringen bij Europcar</p>
+                    <ul>
+                        <li>
+                            <Icons type="users" width="1.8em" height="1.8em" />
+                            <div>
+                                <p>Niet meer in de rij staan</p>
+                                <p>Je haalt je auto snel op bij de Express balie</p>
+                            </div>
+                        </li>
+                        <li>
+                            <Icons type="forward" width="1.8em" height="1.8em" />
+                            <div>
+                                <p>Het is zo gedaan</p>
+                                <p>
+                                    Bevestig je reservering & identiteit en regel de borg. Klaar
+                                    binnen 5 minuten.
+                                </p>
+                            </div>
+                        </li>
+                        <li>
+                            <Icons type="lock" width="1.7em" height="1.7em" />
+                            <div>
+                                <p>Je informatie is veilig</p>
+                                <p>We beveiligen je data en doen niets zonder jouw toestemming.</p>
+                            </div>
+                        </li>
+                    </ul>
                     <ButtonPrimary
                         type="btn"
                         text="Check in"

--- a/src/components/organisms/loginSteps/loginLanding/loginLanding.styles.js
+++ b/src/components/organisms/loginSteps/loginLanding/loginLanding.styles.js
@@ -13,31 +13,51 @@ export const LoginLanding = styled.section`
             display: flex;
             margin: auto;
             &:first-child {
-                width: 155px;
-                height: 30px;
-                padding: 15vh 0 5vh;
+                width: 150px;
+                height: 25px;
+                padding: 6vh 0 4vh;
             }
             &:nth-child(2) {
-                width: 70vw;
+                width: 60vw;
             }
         }
         h1 {
             text-align: center;
             color: white;
-            margin-top: 5vh;
-            line-height: 1.4em;
-        }
-        p {
-            text-align: center;
-            color: white;
-            margin: 2vh 4em 0;
-            line-height: 1.4em;
+            margin: 2.5vh 0 5.5vh 0;
+            font-size: 1.5em;
         }
         button {
             position: absolute;
-            bottom: 10vh;
+            bottom: 5vh;
             left: 50%;
             transform: translateX(-50%);
+        }
+        ul {
+            list-style-type: none;
+            margin: 0 auto;
+            padding: 0 3.5em;
+            li {
+                display: flex;
+                margin-bottom: 1.5em;
+                span {
+                    margin-right: 1em;
+                }
+                div {
+                    p {
+                        margin: 0;
+                        text-align: left;
+                        color: white;
+                        &:first-of-type {
+                            font-weight: bold;
+                            margin: 0 0 0.2em 0;
+                        }
+                    }
+                    &:nth-of-type(2) {
+                        margin: 0;
+                    }
+                }
+            }
         }
     }
     .slideOut {


### PR DESCRIPTION
Add onboarding steps to the home page
Add new icons: `users`, `forward` and `lock`

<img src="https://user-images.githubusercontent.com/60745347/121711166-97006980-cada-11eb-812c-e63a6b3fbc42.png" width="30%" />

Closes #221 